### PR TITLE
Build fixed since boost v1.58

### DIFF
--- a/src/mettle/log_pipe.hpp
+++ b/src/mettle/log_pipe.hpp
@@ -1,6 +1,8 @@
 #ifndef INC_METTLE_SRC_LOG_PIPE_HPP
 #define INC_METTLE_SRC_LOG_PIPE_HPP
 
+#define BOOST_VARIANT_USE_RELAXED_GET_BY_DEFAULT
+
 #include <istream>
 
 #include <mettle/driver/detail/bencode.hpp>


### PR DESCRIPTION
The was a mettle build error with boost v1.58 (default on Ubuntu 16.04 LTS):
```sh
/opt/repos/mettle/src/mettle/posix/../log_pipe.hpp:21:67:   required from here
/usr/include/boost/variant/get.hpp:212:5: error: static assertion failed: boost::variant does not contain specified type U, call to boost::get<U>(boost::variant<T...>&) will always throw boost::bad_get exception
```
The cause is that boost::get<T>() resolves to boost::strict_get<T>() instead of the former boost::relaxed_get<T>() since v 1.58, see details: https://github.com/3Hren/blackhole/issues/64