### PR TITLE
log_pipe build fixed for boost v1.58+ get<>

### DIFF
--- a/src/mettle/log_pipe.hpp
+++ b/src/mettle/log_pipe.hpp
@@ -47,7 +47,7 @@ namespace log {
     std::vector<std::string> read_suites(bencode::data &suites) {
       std::vector<std::string> result;
       for(auto &&i : boost::get<bencode::list>(suites))
-        result.push_back(std::move( boost::get<bencode::string &>(i) ));
+        result.push_back(std::move( boost::get<bencode::string>(i) ));
       return result;
     }
 


### PR DESCRIPTION
Remained statement fixed for the build with boost 1.58+. The cause:
```
/opt/repos/mettle/src/mettle/posix/../log_pipe.hpp:50:68:   required from here
/usr/include/boost/variant/get.hpp:212:5: error: static assertion failed: boost::variant does not contain specified type U, call to boost::get<U>(boost::variant<T...>&) will always throw boost::bad_get exception
     BOOST_STATIC_ASSERT_MSG(
     ^
[11/14] c++ -x c++ -pthread '-std=c++1...d_line.o.d -o src/libmettle/cmd_line.o
ninja: build stopped: subcommand failed.
```
See details in the pull #25.