### PR TITLE
Use exit() instead of _exit() in subprocesses to un-break coverage tools.

### DIFF
--- a/src/libmettle/posix/subprocess.cpp
+++ b/src/libmettle/posix/subprocess.cpp
@@ -20,7 +20,7 @@ namespace posix {
     [[noreturn]] void monitor_failed(std::initializer_list<int> pids = {}) {
       for(int pid : pids)
         kill(pid, SIGKILL);
-      _exit(exit_code::fatal);
+      exit(exit_code::fatal);
     }
 
     inline int size_to_status(int size) {
@@ -39,7 +39,7 @@ namespace posix {
       monitor_failed();
     if(timer_pid == 0) {
       std::this_thread::sleep_for(timeout);
-      _exit(exit_code::timeout);
+      exit(exit_code::timeout);
     }
 
     pid_t test_pid;
@@ -58,7 +58,7 @@ namespace posix {
       wait(nullptr);
 
       if(WIFEXITED(status))
-        _exit(WEXITSTATUS(status));
+        exit(WEXITSTATUS(status));
       else // WIFSIGNALED
         raise(WTERMSIG(status));
     }

--- a/src/libmettle/posix/subprocess_test_runner.cpp
+++ b/src/libmettle/posix/subprocess_test_runner.cpp
@@ -40,7 +40,7 @@ namespace {
   }
 
   [[noreturn]] inline void child_failed() {
-    _exit(exit_code::fatal);
+    exit(exit_code::fatal);
   }
 
   int fd_to_close;
@@ -107,7 +107,7 @@ test_result subprocess_test_runner::operator ()(
 
     fflush(nullptr);
 
-    _exit(result.passed ? exit_code::success : exit_code::failure);
+    exit(result.passed ? exit_code::success : exit_code::failure);
   } else {
     scoped_sigaction sigint, sigquit, sigchld;
 


### PR DESCRIPTION
Test coverage tools like gcov and llvm-cov work (not surprisingly) by installing their own hooks that run when the process under test launches and exits.  Apparently, the difference between _exit(2) and exit(3) is that _exit() aborts the process before those hooks run, and exit() does a heavier and more dignified cleanup, including running the coverage hooks, if installed.

The result is that without this commit, Mettle executables cannot be measured for test coverage 8-(

My experiments suggest that swapping out _exit() for exit() fixes these tools, at least most of the way.  I still have chunks of code that I know are running, but do not get added to the coverage reports.  I think these sections might be in the static initialization of mettle's test suites, but I have not actually figured it out yet.

With this commit, however, *most* of the code that runs during the test execution does, in fact, get reported as covered.  With these changes, I have succeeded in getting coverage reports from Mettle uploaded to codecov.io via CircleCI.

This appears to be a pretty simple PR, once the problem was identified, although there could be a reason for the original choice of _exit(2) over exit(3) of which I am unaware.

