### PR TITLE
Change arithmetic.hpp to use Koenig lookup for max() and abs()

### DIFF
--- a/include/mettle/matchers/arithmetic.hpp
+++ b/include/mettle/matchers/arithmetic.hpp
@@ -20,11 +20,7 @@ namespace mettle {
         // If one of expected or actual is NaN, mag is undefined, but that's ok
         // because we'll always return false in that case, just like we should.
 		
-		// Usually, T is a builtin scalar type supporting standard overloads
-		// std::max<T>() and std::abs<T>().  Occasionally, however, this is not
-		// true (i.e., T is a half precision float).  Koenig lookup for abs(
-		// and max() allows T to be a user defined type, with custom overloads
-		// for these functions.
+        using std::max, std::abs;
         auto mag = max(abs(expected), abs(actual));
         return abs(actual - expected) <= mag * epsilon;
       }, "~= "
@@ -48,6 +44,7 @@ namespace mettle {
       [tolerance = std::forward<U>(tolerance)](
         const auto &actual, const auto &expected
       ) -> bool {
+        using std::abs;
         return abs(actual - expected) <= tolerance;
       }, "~= "
     );

--- a/include/mettle/matchers/arithmetic.hpp
+++ b/include/mettle/matchers/arithmetic.hpp
@@ -19,8 +19,14 @@ namespace mettle {
       ) -> bool {
         // If one of expected or actual is NaN, mag is undefined, but that's ok
         // because we'll always return false in that case, just like we should.
-        auto mag = std::max(std::abs(expected), std::abs(actual));
-        return std::abs(actual - expected) <= mag * epsilon;
+		
+		// Usually, T is a builtin scalar type supporting standard overloads
+		// std::max<T>() and std::abs<T>().  Occasionally, however, this is not
+		// true (i.e., T is a half precision float).  Koenig lookup for abs(
+		// and max() allows T to be a user defined type, with custom overloads
+		// for these functions.
+        auto mag = max(abs(expected), abs(actual));
+        return abs(actual - expected) <= mag * epsilon;
       }, "~= "
     );
   }
@@ -42,7 +48,7 @@ namespace mettle {
       [tolerance = std::forward<U>(tolerance)](
         const auto &actual, const auto &expected
       ) -> bool {
-        return std::abs(actual - expected) <= tolerance;
+        return abs(actual - expected) <= tolerance;
       }, "~= "
     );
   }


### PR DESCRIPTION
I managed to use Mettle's standard arithmetic matchers with Cuda's `__half` type (16 bit IEEE floating point) by providing overloads for `max(__half)` and `abs(__half)`, and template specialization `std::numeric_limits<__half>`.  This small patch changes `arithmetic.hpp` to use Koenig lookup for the overloads, because apparently we cannot put specialized functions inside `std::`.

Maybe there is a more elegant way to work this out, but this solution is the one that I found.

I have tested this in my own application which builds Mettle in a non-standard (and loathsome) CMake build.  I have not tested it with Mettle's default build system.