### PR TITLE
Fix compatibility with latest bencode.hpp

### DIFF
--- a/include/mettle/driver/log/child.hpp
+++ b/include/mettle/driver/log/child.hpp
@@ -15,27 +15,27 @@ namespace mettle::log {
     child(std::ostream &out) : out(out) {}
 
     void started_run() override {
-      bencode::encode(out, bencode::dict_view{
+      bencode::encode_to(out, bencode::dict_view{
         {"event", "started_run"}
       });
       out.flush();
     }
     void ended_run() override {
-      bencode::encode(out, bencode::dict_view{
+      bencode::encode_to(out, bencode::dict_view{
         {"event", "ended_run"}
       });
       out.flush();
     }
 
     void started_suite(const std::vector<std::string> &suites) override {
-      bencode::encode(out, bencode::dict_view{
+      bencode::encode_to(out, bencode::dict_view{
         {"event", "started_suite"},
         {"suites", wrap_suites(suites)}
       });
       out.flush();
     }
     void ended_suite(const std::vector<std::string> &suites) override {
-      bencode::encode(out, bencode::dict_view{
+      bencode::encode_to(out, bencode::dict_view{
         {"event", "ended_suite"},
         {"suites", wrap_suites(suites)}
       });
@@ -43,7 +43,7 @@ namespace mettle::log {
     }
 
     void started_test(const test_name &test) override {
-      bencode::encode(out, bencode::dict_view{
+      bencode::encode_to(out, bencode::dict_view{
         {"event", "started_test"},
         {"test", wrap_test(test)}
       });
@@ -52,7 +52,7 @@ namespace mettle::log {
 
     void passed_test(const test_name &test, const test_output &output,
                      test_duration duration) override {
-      bencode::encode(out, bencode::dict_view{
+      bencode::encode_to(out, bencode::dict_view{
         {"event", "passed_test"},
         {"test", wrap_test(test)},
         {"duration", duration.count()},
@@ -64,7 +64,7 @@ namespace mettle::log {
     void failed_test(const test_name &test, const std::string &message,
                      const test_output &output,
                      test_duration duration) override {
-      bencode::encode(out, bencode::dict_view{
+      bencode::encode_to(out, bencode::dict_view{
         {"event", "failed_test"},
         {"test", wrap_test(test)},
         {"duration", duration.count()},
@@ -76,7 +76,7 @@ namespace mettle::log {
 
     void skipped_test(const test_name &test,
                       const std::string &message) override {
-      bencode::encode(out, bencode::dict_view{
+      bencode::encode_to(out, bencode::dict_view{
         {"event", "skipped_test"},
         {"test", wrap_test(test)},
         {"message", message}

--- a/src/mettle/log_pipe.hpp
+++ b/src/mettle/log_pipe.hpp
@@ -15,7 +15,7 @@ namespace mettle::log {
       : logger_(logger), file_uid_(file_uid) {}
 
     void operator ()(std::istream &s) {
-      auto tmp = bencode::decode(s, bencode::no_check_eof);
+      auto tmp = bencode::decode_some(s, bencode::no_check_eof);
       auto &data = std::get<bencode::dict>(tmp);
       auto &&event = std::get<bencode::string>(data.at("event"));
 

--- a/src/mettle/posix/run_test_file.cpp
+++ b/src/mettle/posix/run_test_file.cpp
@@ -56,7 +56,7 @@ namespace mettle::posix {
         io::stream<io::file_descriptor_sink> stream(
           fd, io::never_close_handle
         );
-        bencode::encode(stream, bencode::dict_view{
+        bencode::encode_to(stream, bencode::dict_view{
           {"event", "failed_file"},
           {"file", file},
           {"message", err}


### PR DESCRIPTION
Trivial fix, updated invocations for the sake of compatibility with latest bencode.hpp:

* `bencode::encode` -> `bencode::encode_to`
* `bencode::decode` -> `bencode::decode_some`