### PR TITLE
Fix presence detection of libcxx.h

### DIFF
--- a/include/mettle/output/type_name.hpp
+++ b/include/mettle/output/type_name.hpp
@@ -58,7 +58,7 @@ namespace mettle {
 
 } // namespace mettle
 
-#if defined(__clang__) || defined(__GNUG__)
+#if __has_include(<cxxabi.h>)
 
 #include <cxxabi.h>
 


### PR DESCRIPTION
We should check libcxx.h is present instead of just checking the compiler.
Because on Windows using clang compiler this file is not present and the compilation fails.

Since mettle already requires C++20, using `__has_include` feature seems to be the most accurate way of detecting this.