### PR TITLE
Work around Clang/Windows init order bug by using static all_suites

### DIFF
--- a/include/mettle/suite/detail/all_suites.hpp
+++ b/include/mettle/suite/detail/all_suites.hpp
@@ -5,7 +5,7 @@
 
 namespace mettle::detail {
 
-  inline suites_list all_suites;
+  static suites_list all_suites;
 
 } // namespace mettle::detail
 


### PR DESCRIPTION
This change replaces the inline definition of `all_suites` with a `static` one to avoid static initialization order issues, particularly on Clang + Windows.

This ensures `all_suites` is initialized before any static test registrations, in accordance with the C++ standard, which guarantees initialization order for static variables within a single translation unit.

However, this imposes a limit on test executable to have only one translation unit. Not sure how to do it better without explicit initialization point and slightly more boilerplate, which this patch avoids for now.

Fixes #52