### PR TITLE
Correctly handle Unicode paths on Windows

### DIFF
--- a/build.bfg
+++ b/build.bfg
@@ -16,6 +16,8 @@ prog_opts = package('boost', 'program_options', version='>=1.55')
 compile_opts = [opts.define('METTLE_VERSION', '"{}"'.format(mettle_version))]
 if argv.safe_exit:
     compile_opts.append(opts.define('METTLE_SAFE_EXIT'))
+if env.target_platform.family == 'windows':
+    compile_opts.append(opts.define('UNICODE'))
 
 includes = header_directory('include', include='**/*.hpp')
 

--- a/src/libmettle/windows/subprocess_test_runner.cpp
+++ b/src/libmettle/windows/subprocess_test_runner.cpp
@@ -49,15 +49,16 @@ namespace mettle {
        !log_pipe.set_write_inherit(true))
       return METTLE_FAILED();
 
-    char file[_MAX_PATH];
-    if(GetModuleFileNameA(nullptr, file, sizeof(file)) == sizeof(file))
+    TCHAR file[_MAX_PATH];
+    DWORD result = GetModuleFileName(nullptr, file, _countof(file));
+    if (result == 0 || result >= sizeof(file))
       return METTLE_FAILED();
 
-    std::ostringstream args;
-    args << file << " --test-id " << test.id << " --log-fd "
+    std::basic_ostringstream<TCHAR> args;
+    args << file << TEXT(" --test-id ") << test.id << TEXT(" --log-fd ")
          << log_pipe.write_handle.handle();
 
-    STARTUPINFOA startup_info = { sizeof(STARTUPINFOA) };
+    STARTUPINFO startup_info = { sizeof(STARTUPINFO) };
     startup_info.dwFlags = STARTF_USESTDHANDLES;
     startup_info.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
     startup_info.hStdOutput = stdout_pipe.write_handle;
@@ -80,8 +81,8 @@ namespace mettle {
         return METTLE_FAILED();
     }
 
-    if(!CreateProcessA(
-         file, const_cast<char*>(args.str().c_str()), nullptr, nullptr, true,
+    if(!CreateProcess(
+         nullptr, const_cast<PTCHAR>(args.str().c_str()), nullptr, nullptr, true,
          CREATE_SUSPENDED, nullptr, nullptr, &startup_info, &proc_info
        )) {
       return METTLE_FAILED();


### PR DESCRIPTION
Currently on Windows it's not possible to run tests using either `mettle.exe` or subprocess test runner if the path contains unicode characters.

It happens because `CreateProcessA` and `GetModuleFileNameA` are not Unicode-aware.

The right way is to use generic function prototypes and select -`A` or -`W` function version depending on the `UNICODE` definition as described [here](https://learn.microsoft.com/en-us/windows/win32/intl/conventions-for-function-prototypes).

Also added `UNICODE` definition by default to build.bfg on Windows platform.